### PR TITLE
Fix/input field width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interbtc-ui",
-  "version": "2.28.8",
+  "version": "2.28.9",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.1.1",

--- a/src/pages/Staking/LockTimeField/index.tsx
+++ b/src/pages/Staking/LockTimeField/index.tsx
@@ -50,7 +50,7 @@ const LockTimeField = React.forwardRef<Ref, CustomProps & NumberInputProps>(
           className={clsx('!text-xs', LABEL_TEXT_COLOR_CLASSES)}
           required={optional === false}
         >
-          Max {STAKE_LOCK_TIME.MAX} Weeks
+          Total {STAKE_LOCK_TIME.MAX} Weeks
         </TextFieldLabel>
         <div className={clsx('flex', 'justify-between', 'items-center')}>
           {optional === true && (

--- a/src/pages/Staking/LockTimeField/index.tsx
+++ b/src/pages/Staking/LockTimeField/index.tsx
@@ -65,7 +65,7 @@ const LockTimeField = React.forwardRef<Ref, CustomProps & NumberInputProps>(
             <NumberInput
               ref={ref}
               id={id}
-              className={clsx('!w-12', {
+              className={clsx('!w-14', {
                 [clsx(
                   { 'border-interlayCinnabar': process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
                   { 'dark:border-kintsugiThunderbird': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },


### PR DESCRIPTION
## Description
There are two issues fixed in this PR, [OG ISSUE](https://github.com/interlay/interbtc-ui/issues/940)

## Current behaviour (updates)
1. When you enter more than 3 digital in the lockin time field of staking tab, one digit is cut off
2. User messaging is confusing—it implies 192 extra weeks, rather than total weeks

## New behaviour
1. Supports 3 digits
2. Improved UX sensibility by changing the text

## Reproducible testing steps:
1. Enter three digits in lockin field of staking tab
