### PR TITLE
Fix/negative apy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interbtc-ui",
-  "version": "2.29.6",
+  "version": "2.29.7",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.1.1",

--- a/src/components/LoanPositionsTable/ApyCell.tsx
+++ b/src/components/LoanPositionsTable/ApyCell.tsx
@@ -17,6 +17,7 @@ type ApyCellProps = {
   rewards: MonetaryAmount<CurrencyExt> | null;
   prices?: Prices;
   isBorrow?: boolean;
+  negativeApy?: boolean;
   onClick?: () => void;
 };
 
@@ -28,12 +29,13 @@ const ApyCell = ({
   earnedInterest,
   prices,
   isBorrow = false,
+  negativeApy = false,
   onClick
 }: ApyCellProps): JSX.Element => {
   const rewardsApy = getSubsidyRewardApy(currency, rewards, prices);
 
   const totalApy = isBorrow ? apy.sub(rewardsApy || 0) : apy.add(rewardsApy || 0);
-  const totalApyLabel = getApyLabel(totalApy);
+  const totalApyLabel = negativeApy ? `- ${getApyLabel(totalApy)}` : getApyLabel(totalApy);
 
   const earnedAsset = accumulatedDebt || earnedInterest;
 

--- a/src/pages/Loans/LoansOverview/components/BorrowAssetsTable/BorrowAssetsTable.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowAssetsTable/BorrowAssetsTable.tsx
@@ -60,6 +60,7 @@ const BorrowAssetsTable = ({ assets, onRowAction, ...props }: BorrowAssetsTableP
             rewards={borrowReward}
             prices={prices}
             isBorrow
+            negativeApy
             // TODO: temporary until we find why row click is being ignored
             onClick={() => onRowAction?.(currency.ticker as Key)}
           />


### PR DESCRIPTION
## Description

Add a "-" symbol for the borrow APY [OG issue](https://github.com/interlay/interbtc-ui/issues/1122)

## New behaviour
Adding a "-" makes it more clear to the user that borrow APY accumulates cost and will need to be paid back.


## Reproducible steps:

Go to Lending tab -> focus on borrow APY table -> there should be a negative in front of all the borrow APY values
